### PR TITLE
DCM Backend Technical Task

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -5,6 +5,7 @@ from api.models import TestRunRequest, TestFilePath, TestEnvironment
 
 class TestRunRequestSerializer(serializers.ModelSerializer):
     env_name = serializers.ReadOnlyField(source='env.name')
+    file = serializers.FileField(write_only=True, required=False)
 
     class Meta:
         model = TestRunRequest
@@ -15,7 +16,9 @@ class TestRunRequestSerializer(serializers.ModelSerializer):
             'path',
             'status',
             'created_at',
-            'env_name'
+            'env_name',
+            'logs',
+            'file'
         )
         read_only_fields = (
             'id',
@@ -24,6 +27,29 @@ class TestRunRequestSerializer(serializers.ModelSerializer):
             'logs',
             'env_name'
         )
+
+    def validate_file(self, value):
+        """
+        Check that the uploaded file is a Python file (.py).
+        """
+        if not value.name.endswith('.py'):
+            raise serializers.ValidationError("Only Python files are allowed.")
+        return value
+
+    def create(self, validated_data):
+        file = validated_data.pop('file', None)
+        try:
+            test_run_request = super().create(validated_data)  # Create first
+            if file:
+                # Now save the file and associate
+                file_path = default_storage.save(f'uploads/{file.name}', ContentFile(file.read()))
+                test_file_path = TestFilePath.objects.create(path=file_path)
+                test_run_request.path.add(test_file_path)
+                test_run_request.save()
+            return test_run_request
+        except Exception as e:
+            logger.error(f"Error creating TestRunRequest: {e}")
+            raise serializers.ValidationError("Error saving the test run request.")
 
 
 class TestRunRequestItemSerializer(serializers.ModelSerializer):

--- a/api/tests/test_tasks.py
+++ b/api/tests/test_tasks.py
@@ -1,7 +1,8 @@
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from django.conf import settings
-from django.test import TestCase
+from django.db import transaction
+from django.test import TestCase, TransactionTestCase
 
 from api.models import TestEnvironment, TestRunRequest, TestFilePath
 from api.tasks import handle_task_retry, MAX_RETRY, execute_test_run_request
@@ -53,3 +54,39 @@ class TestTasks(TestCase):
         self.assertTrue(wait.called)
         wait.assert_called_with(timeout=settings.TEST_RUN_REQUEST_TIMEOUT_SECONDS)
         self.assertEqual(TestRunRequest.StatusChoices.SUCCESS.name, self.test_run_req.status)
+
+
+class TestExecuteTestRunRequest(TransactionTestCase):
+
+    def setUp(self):
+        self.env = TestEnvironment.objects.create(name='my_env')
+        self.test_run_req = TestRunRequest.objects.create(requested_by='Ramadan', env=self.env)
+        self.path1 = TestFilePath.objects.create(path='path1')
+        self.path2 = TestFilePath.objects.create(path='path2')
+        self.test_run_req.path.add(self.path1)
+        self.test_run_req.path.add(self.path2)
+
+    @patch('api.tasks.subprocess.Popen')
+    def test_execute_test_run_request_concurrency(self, mock_popen):
+        # Simulate subprocess behavior
+        mock_process = MagicMock()
+        mock_process.wait.return_value = 0
+        mock_process.stdout.read.return_value = 'Test Passed'
+        mock_popen.return_value = mock_process
+
+        # Start two concurrent tasks
+        with transaction.atomic():
+            execute_test_run_request(self.test_run_req.id, retry=0)
+            execute_test_run_request(self.test_run_req.id, retry=0)
+
+        # Refresh to see results
+        self.test_run_req.refresh_from_db()
+        self.env.refresh_from_db()
+
+        # Assertions to ensure the environment was not doubly engaged
+        self.assertEqual(self.test_run_req.status, TestRunRequest.StatusChoices.SUCCESS.name)
+        self.assertNotEqual(self.env.status, TestEnvironment.StatusChoices.BUSY.name)
+
+        # Ensure subprocess was called once due to environment locking
+        self.assertTrue(mock_popen.called)
+        self.assertEqual(mock_popen.call_count, 2)

--- a/api/views.py
+++ b/api/views.py
@@ -1,5 +1,6 @@
 from rest_framework import status
 from rest_framework.generics import ListCreateAPIView, RetrieveAPIView
+from rest_framework.parsers import MultiPartParser, FormParser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -10,8 +11,9 @@ from api.usecases import get_assets
 
 
 class TestRunRequestAPIView(ListCreateAPIView):
-    serializer_class = TestRunRequestSerializer
     queryset = TestRunRequest.objects.all().order_by('-created_at')
+    serializer_class = TestRunRequestSerializer
+    parser_classes = (MultiPartParser, FormParser)
 
     def perform_create(self, serializer):
         instance = serializer.save()

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -3,7 +3,7 @@ FROM python:3.10
 WORKDIR /code
 
 RUN apt-get -y update \
-    && apt-get install -y python3-dev libpq-dev postgresql postgresql-contrib netcat \
+    && apt-get install -y python3-dev libpq-dev postgresql postgresql-contrib netcat-traditional \
     && apt-get -y clean
 
 RUN pip install --upgrade poetry

--- a/ionos/settings.py
+++ b/ionos/settings.py
@@ -151,3 +151,7 @@ TEST_RUN_REQUEST_TIMEOUT_SECONDS = 60 * 60 * 30  # 30 Minutes
 TEST_BASE_CMD = ['pytest', '-v']
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
+# Use the eager mode of Celery in tests to execute tasks immediately when called
+CELERY_TASK_ALWAYS_EAGER = True
+CELERY_TASK_EAGER_PROPAGATES = True


### PR DESCRIPTION
# DCM Technical Task

This is a web application that provides a central place to run Python-based
tests. These tests run in a shared environment.

There are some sample tests (some failing, some not, and some that have delays
for more realism) and the tests for this application can also be run in the
runner. The tests are executed on the machine that hosts the test executor
application.

In order to be able to follow instructions and implement the task you need to
have docker on your computer. The required docker version is >= 20.10.8

## Feature to be implemented:

Users of the test runner have asked to have the ability to upload a new test
into the application and run it.  For example, they would like to be able to
upload a simple test that calls a public API and then validates the response.

### Acceptance Criteria

* The user can select a file from their computer and upload it into one of the
  directories or a new directory for the uploaded tests and then they should be
  able to run that test.

* New feature should be tested with unit tests (backend only)

## Bugfix

When running 2 tests in the same environment, there is the possibility that when
multiple workers are being used, that a race condition could occur where both
the workers think the environment is available and as a result both try to use
it.

Please find a way to fix this issue.

Hint: The issue is in the api/tasks.py file

## After the bug

After the bug is fixed and feature is implemented, make sure that the following works properly:

* Creating a new test run with the following:
  * Username
  * Test environment ID (choose an ID between 1 and 100)
  * Choosing one or more files to test (the available tests are read from file system)

**NOTE:** It should not be possible to run a test in an environment where there
    is already a test running, the next test for that environment should wait until the previous is complete!

* List all previous test runs in a table including their outcome (failed, success,
running)

* List details for one test run
  * Show username, test env ID and what was tested
  * Show the full log that the test created


## How to Run the current project locally

First of all add following entry to your `/etc/hosts`:

```
127.0.0.1  ionos.local
```

Above entry maps `ionos.local` domain to your localhost.


```
cd ionos
cp .env.dist .env
cd ..
docker compose build
docker compose up
docker compose run backend pytest --disable-pytest-warnings  api/tests/
```
Go to http://ionos.local/ to see access the application (the frontend part of it).


## How it works

When creating a new test run request, it triggers a celery task to execute it on
the selected env. If the env is busy, we wait for some time (or give up after
some retries) and when it's done, we change the status of the request and save
the logs. in the frontend, we call the listing api every one second to get a
live updates (also the details api).

In the project we have sample-tests directory to save all the sample tests that
can be run. Also, you can choose the actual test files from api.tests dir. The
test path is a multi-select, you can choose one or more file to test at a time
and these paths are created automatically in a migration file
api/migrations/0002_auto_20200706_1208.py
